### PR TITLE
Added Santali language

### DIFF
--- a/config/eleven-plus.yaml
+++ b/config/eleven-plus.yaml
@@ -184,7 +184,9 @@ files:
         # Romansh
         rm-CH: rm
         # Russian
-        ru: ru
+        ru: ru 
+        # Santali
+        sat: sat
         # Sardinian
         sc: sc-rIT
         # Scottish Gaelic

--- a/config/eleven.yaml
+++ b/config/eleven.yaml
@@ -184,7 +184,9 @@ files:
         # Romansh
         rm-CH: rm
         # Russian
-        ru: ru
+        ru: ru 
+        # Santali
+        sat: sat
         # Sardinian
         sc: sc-rIT
         # Scottish Gaelic


### PR DESCRIPTION
Santali language was missing from the list. So, i have added the language codes into it. The language was not syncing with the Crowdin Translation for Santali Language.